### PR TITLE
Generics

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -86,5 +86,23 @@ impl Foo for i32 {
 # TODO
 - Add nested pattern matching
 - Add completeness checking for pattern matching
-- Add tuple enum variants
-- Add empty enum variants
+- ~~Add tuple enum variants~~
+- ~~Add empty enum variants~~
+
+# Consolidate Structs and Emums
+
+Have a single struct rule that can take either one identifier or two identifiers separated by `::`.
+In the symbol table we index by the full name, i.e. `Foo::Bar` or `Bar`. Somewhere we have to 
+store the other variants in an enum.
+
+Do we want to encode this in the `Type` type? Because right now we just say it's a named type,
+which doesn't give any sort of info about the type itself, and is more a syntactic 
+representation. Perhaps it should be a more sophisticated struct/enum type with type
+substitutions.
+
+# TODO:
+- Add type checker output printing/playground
+- Figure out how tuple enums work (should we bite the bullet and use type checker information?)
+  - Or define functions that produce an enum representation? 
+  
+

--- a/crates/vicuna-compiler/Cargo.toml
+++ b/crates/vicuna-compiler/Cargo.toml
@@ -12,7 +12,7 @@ wasm-opt = false
 anyhow = { workspace = true }
 chumsky = { version = "0.9.2", default-features = false, features = ["std"] }
 miette = { version = "5.8.0", features = ["fancy"] }
-serde = { version = "1.0.147", features = ["derive"] }
+serde = { version = "1.0.147", features = ["derive", "rc"] }
 thiserror = "1.0.40"
 tracing = "0.1.37"
 

--- a/crates/vicuna-compiler/src/ast.rs
+++ b/crates/vicuna-compiler/src/ast.rs
@@ -16,11 +16,31 @@ impl<T: Debug + Clone + PartialEq + Serialize + Hash> Eq for Span<T> {}
 type TypeParams = Span<Vec<Span<String>>>;
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
-pub enum TypeFields {
-    Named(Vec<(Span<String>, Span<TypeSig>)>),
-    Tuple(Vec<Span<TypeSig>>),
+pub enum Fields<T: Debug + Clone + PartialEq + Serialize> {
+    Named(Vec<(Span<String>, Span<T>)>),
+    Tuple(Vec<Span<T>>),
     Empty,
 }
+
+impl<T: Debug + Clone + PartialEq + Serialize> Fields<T> {
+    pub fn map<U: Debug + Clone + PartialEq + Serialize>(
+        &self,
+        mut f: impl FnMut(&Span<T>) -> Span<U>,
+    ) -> Fields<U> {
+        match self {
+            Fields::Named(fields) => Fields::Named(
+                fields
+                    .iter()
+                    .map(|(name, value)| (name.clone(), f(value)))
+                    .collect(),
+            ),
+            Fields::Tuple(fields) => Fields::Tuple(fields.iter().map(|value| f(value)).collect()),
+            Fields::Empty => Fields::Empty,
+        }
+    }
+}
+
+pub type TypeFields = Fields<TypeSig>;
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub enum TypeDeclaration {
@@ -84,6 +104,18 @@ pub struct ExprBlock {
     pub end_expr: Option<Box<Span<Expr>>>,
 }
 
+pub type ExprFields = Fields<Expr>;
+
+impl ExprFields {
+    pub fn len(&self) -> usize {
+        match self {
+            ExprFields::Tuple(fields) => fields.len(),
+            ExprFields::Named(fields) => fields.len(),
+            ExprFields::Empty => 0,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub enum Expr {
     Value(Value),
@@ -94,11 +126,11 @@ pub enum Expr {
     PostFix(Box<Span<Expr>>, Span<PostFix>),
     Binary(Span<BinaryOp>, Box<Span<Expr>>, Box<Span<Expr>>),
     Unary(Span<UnaryOp>, Box<Span<Expr>>),
-    Struct(Span<String>, Vec<(Span<String>, Span<Expr>)>),
+    Struct(Span<String>, ExprFields),
     Enum {
         enum_name: Span<String>,
         variant_name: Span<String>,
-        fields: Vec<(Span<String>, Span<Expr>)>,
+        fields: ExprFields,
     },
     // If expressions are not available in all places, because they
     // don't transpile cleanly to JavaScript. Instead, they're only

--- a/crates/vicuna-compiler/src/ast.rs
+++ b/crates/vicuna-compiler/src/ast.rs
@@ -193,7 +193,9 @@ pub enum TypeSig {
     F32,
     String,
     Bool,
-    Named(String),
+    // This could technically be consolidated with the above one,
+    // but I want to keep a "happy path"
+    Named(Span<String>, Vec<Span<TypeSig>>),
 }
 
 impl Eq for TypeSig {}

--- a/crates/vicuna-compiler/src/ast.rs
+++ b/crates/vicuna-compiler/src/ast.rs
@@ -16,16 +16,23 @@ impl<T: Debug + Clone + PartialEq + Serialize + Hash> Eq for Span<T> {}
 type TypeParams = Span<Vec<Span<String>>>;
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
+pub enum TypeFields {
+    Named(Vec<(Span<String>, Span<TypeSig>)>),
+    Tuple(Vec<Span<TypeSig>>),
+    Empty,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub enum TypeDeclaration {
     Struct {
         name: Span<String>,
         type_parameters: Option<TypeParams>,
-        fields: Vec<(Span<String>, Span<TypeSig>)>,
+        fields: TypeFields,
     },
     Enum {
         name: Span<String>,
         type_parameters: Option<TypeParams>,
-        variants: Vec<(Span<String>, Vec<(Span<String>, Span<TypeSig>)>)>,
+        variants: Vec<(Span<String>, TypeFields)>,
     },
 }
 

--- a/crates/vicuna-compiler/src/ast.rs
+++ b/crates/vicuna-compiler/src/ast.rs
@@ -13,14 +13,18 @@ pub struct Span<T: Debug + Clone + PartialEq + Serialize>(pub T, pub Range<usize
 
 impl<T: Debug + Clone + PartialEq + Serialize + Hash> Eq for Span<T> {}
 
+type TypeParams = Span<Vec<Span<String>>>;
+
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub enum TypeDeclaration {
     Struct {
         name: Span<String>,
+        type_parameters: Option<TypeParams>,
         fields: Vec<(Span<String>, Span<TypeSig>)>,
     },
     Enum {
         name: Span<String>,
+        type_parameters: Option<TypeParams>,
         variants: Vec<(Span<String>, Vec<(Span<String>, Span<TypeSig>)>)>,
     },
 }

--- a/crates/vicuna-compiler/src/snapshots/vicuna_compiler__parser__tests__parse_enum_declaration-2.snap
+++ b/crates/vicuna-compiler/src/snapshots/vicuna_compiler__parser__tests__parse_enum_declaration-2.snap
@@ -8,9 +8,10 @@ Ok:
       - Foo
       - start: 4
         end: 9
+    type_parameters: ~
     variants:
       - - - A
           - start: 11
             end: 13
-        - []
+        - Empty
 

--- a/crates/vicuna-compiler/src/snapshots/vicuna_compiler__parser__tests__parse_enum_declaration-3.snap
+++ b/crates/vicuna-compiler/src/snapshots/vicuna_compiler__parser__tests__parse_enum_declaration-3.snap
@@ -8,14 +8,16 @@ Ok:
       - Foo
       - start: 4
         end: 9
+    type_parameters: ~
     variants:
       - - - A
           - start: 11
             end: 13
-        - - - - foo
-              - start: 15
-                end: 18
-            - - String
-              - start: 19
-                end: 27
+        - Named:
+            - - - foo
+                - start: 15
+                  end: 18
+              - - String
+                - start: 19
+                  end: 27
 

--- a/crates/vicuna-compiler/src/snapshots/vicuna_compiler__parser__tests__parse_enum_declaration.snap
+++ b/crates/vicuna-compiler/src/snapshots/vicuna_compiler__parser__tests__parse_enum_declaration.snap
@@ -8,17 +8,18 @@ Ok:
       - Foo
       - start: 4
         end: 9
+    type_parameters: ~
     variants:
       - - - A
           - start: 11
             end: 12
-        - []
+        - Empty
       - - - B
           - start: 14
             end: 15
-        - []
+        - Empty
       - - - C
           - start: 17
             end: 19
-        - []
+        - Empty
 

--- a/crates/vicuna-compiler/src/snapshots/vicuna_compiler__parser__tests__parse_struct_declaration-2.snap
+++ b/crates/vicuna-compiler/src/snapshots/vicuna_compiler__parser__tests__parse_struct_declaration-2.snap
@@ -8,5 +8,7 @@ Ok:
       - Foo
       - start: 6
         end: 11
-    fields: []
+    type_parameters: ~
+    fields:
+      Named: []
 

--- a/crates/vicuna-compiler/src/snapshots/vicuna_compiler__parser__tests__parse_struct_declaration-3.snap
+++ b/crates/vicuna-compiler/src/snapshots/vicuna_compiler__parser__tests__parse_struct_declaration-3.snap
@@ -8,11 +8,13 @@ Ok:
       - Foo
       - start: 6
         end: 11
+    type_parameters: ~
     fields:
-      - - - a
-          - start: 13
-            end: 14
-        - - I32
-          - start: 15
-            end: 20
+      Named:
+        - - - a
+            - start: 13
+              end: 14
+          - - I32
+            - start: 15
+              end: 20
 

--- a/crates/vicuna-compiler/src/snapshots/vicuna_compiler__parser__tests__parse_struct_declaration-4.snap
+++ b/crates/vicuna-compiler/src/snapshots/vicuna_compiler__parser__tests__parse_struct_declaration-4.snap
@@ -8,11 +8,13 @@ Ok:
       - Foo
       - start: 6
         end: 11
+    type_parameters: ~
     fields:
-      - - - a
-          - start: 13
-            end: 14
-        - - I32
-          - start: 15
-            end: 19
+      Named:
+        - - - a
+            - start: 13
+              end: 14
+          - - I32
+            - start: 15
+              end: 19
 

--- a/crates/vicuna-compiler/src/snapshots/vicuna_compiler__parser__tests__parse_struct_declaration.snap
+++ b/crates/vicuna-compiler/src/snapshots/vicuna_compiler__parser__tests__parse_struct_declaration.snap
@@ -8,17 +8,19 @@ Ok:
       - Foo
       - start: 6
         end: 11
+    type_parameters: ~
     fields:
-      - - - a
-          - start: 13
-            end: 14
-        - - I32
-          - start: 15
-            end: 19
-      - - - b
-          - start: 21
-            end: 22
-        - - I32
-          - start: 23
-            end: 28
+      Named:
+        - - - a
+            - start: 13
+              end: 14
+          - - I32
+            - start: 15
+              end: 19
+        - - - b
+            - start: 21
+              end: 22
+          - - I32
+            - start: 23
+              end: 28
 

--- a/crates/vicuna-compiler/src/snapshots/vicuna_compiler__parser__tests__parse_struct_literal-2.snap
+++ b/crates/vicuna-compiler/src/snapshots/vicuna_compiler__parser__tests__parse_struct_literal-2.snap
@@ -1,19 +1,20 @@
 ---
 source: crates/vicuna-compiler/src/parser.rs
-expression: "expr().parse(\"Foo { a: 10 }\")"
+expression: "expression().parse(\"Foo { a: 10 }\")"
 ---
 Ok:
   - Struct:
       - - Foo
         - start: 0
           end: 4
-      - - - - a
-            - start: 5
-              end: 7
-          - - Value:
-                I32: 10
-            - start: 9
-              end: 11
+      - Named:
+          - - - a
+              - start: 5
+                end: 7
+            - - Value:
+                  I32: 10
+              - start: 9
+                end: 11
   - start: 0
     end: 13
 

--- a/crates/vicuna-compiler/src/snapshots/vicuna_compiler__parser__tests__parse_struct_literal-3.snap
+++ b/crates/vicuna-compiler/src/snapshots/vicuna_compiler__parser__tests__parse_struct_literal-3.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/vicuna-compiler/src/parser.rs
-expression: "expr().parse(\"Foo::Bar { a: 10, b: 20 }\")"
+expression: "expression().parse(\"Foo::Bar { a: 10, b: 20 }\")"
 ---
 Ok:
   - Enum:
@@ -13,20 +13,21 @@ Ok:
         - start: 5
           end: 9
       fields:
-        - - - a
-            - start: 10
-              end: 12
-          - - Value:
-                I32: 10
-            - start: 14
-              end: 16
-        - - - b
-            - start: 17
-              end: 19
-          - - Value:
-                I32: 20
-            - start: 21
-              end: 23
+        Named:
+          - - - a
+              - start: 10
+                end: 12
+            - - Value:
+                  I32: 10
+              - start: 14
+                end: 16
+          - - - b
+              - start: 17
+                end: 19
+            - - Value:
+                  I32: 20
+              - start: 21
+                end: 23
   - start: 0
     end: 25
 

--- a/crates/vicuna-compiler/src/snapshots/vicuna_compiler__parser__tests__parse_struct_literal.snap
+++ b/crates/vicuna-compiler/src/snapshots/vicuna_compiler__parser__tests__parse_struct_literal.snap
@@ -1,26 +1,27 @@
 ---
 source: crates/vicuna-compiler/src/parser.rs
-expression: "expr().parse(\"Foo { a: 10, b: 20 }\")"
+expression: "expression().parse(\"Foo { a: 10, b: 20 }\")"
 ---
 Ok:
   - Struct:
       - - Foo
         - start: 0
           end: 4
-      - - - - a
-            - start: 5
-              end: 7
-          - - Value:
-                I32: 10
-            - start: 9
-              end: 11
-        - - - b
-            - start: 12
-              end: 14
-          - - Value:
-                I32: 20
-            - start: 16
-              end: 18
+      - Named:
+          - - - a
+              - start: 5
+                end: 7
+            - - Value:
+                  I32: 10
+              - start: 9
+                end: 11
+          - - - b
+              - start: 12
+                end: 14
+            - - Value:
+                  I32: 20
+              - start: 16
+                end: 18
   - start: 0
     end: 20
 

--- a/crates/vicuna-compiler/src/type_checker.rs
+++ b/crates/vicuna-compiler/src/type_checker.rs
@@ -144,9 +144,15 @@ impl<T> SymbolTable<T> {
     }
 }
 
+struct StructInfo {
+    fields: HashMap<Name, Type>,
+    // Generic parameters used in struct
+    type_parameters: Vec<Name>,
+}
+
 pub struct TypeChecker {
     symbol_table: SymbolTable<Type>,
-    defined_structs: SymbolTable<HashMap<Name, Type>>,
+    defined_structs: SymbolTable<StructInfo>,
     defined_enums: SymbolTable<HashMap<Name, HashMap<Name, Type>>>,
     return_type: Option<Type>,
     pub(crate) errors: Vec<TypeError>,

--- a/programs/generics.vc
+++ b/programs/generics.vc
@@ -3,14 +3,22 @@ enum Option<T> {
  None
 }
 
-use Option::*;
+let b = Option::Some(20);
 
-fn foo(a: i32) {
-  print(a);
-}
+use Option::*;
 
 let a = Some(10);
 
-let b = Option::Some(20);
+struct Span<T> {
+  start: i32,
+  end: i32,
+  inner: T
+}
 
-let c = foo(30);
+let s = Span {
+  start: 0,
+  end: 20,
+  inner: "Hello, world!"
+};
+
+

--- a/programs/generics.vc
+++ b/programs/generics.vc
@@ -1,0 +1,4 @@
+enum Option<T> {
+  Some(T),
+  None
+}

--- a/programs/generics.vc
+++ b/programs/generics.vc
@@ -1,4 +1,4 @@
 enum Option<T> {
-  Some(T),
-  None
+ Some(T),
+ None
 }

--- a/programs/generics.vc
+++ b/programs/generics.vc
@@ -2,3 +2,5 @@ enum Option<T> {
  Some(T),
  None
 }
+
+let a = Option::Some(10);

--- a/programs/generics.vc
+++ b/programs/generics.vc
@@ -3,4 +3,14 @@ enum Option<T> {
  None
 }
 
-let a = Option::Some(10);
+use Option::*;
+
+fn foo(a: i32) {
+  print(a);
+}
+
+let a = Some(10);
+
+let b = Option::Some(20);
+
+let c = foo(30);

--- a/programs/generics.vc
+++ b/programs/generics.vc
@@ -12,7 +12,7 @@ let a = Some(10);
 struct Span<T> {
   start: i32,
   end: i32,
-  inner: T
+  inner: T,
 }
 
 let s = Span {


### PR DESCRIPTION
Implements generics for structs and enums:

- Creates a struct/enum "schema" which contains the fields and type parameters without substitution. Used behind an `Arc` because they're immutable and shared.
- To represent a fully instantiated type, we pair the schema with the type arguments.

